### PR TITLE
Implements free unit selection

### DIFF
--- a/src/pages/game/ctrl.js
+++ b/src/pages/game/ctrl.js
@@ -1485,7 +1485,7 @@ function openUnitActionMenu(hex) {
 	]).forEach((actionItem) => {
 		const button = document.createElement('button');
 		// Handle both string actions and object actions (for activateUnit)
-        if (typeof actionItem === 'object' && actionItem.action) {
+        if (actionItem?.action) {
             const action = Actions[actionItem.action];
             button.innerHTML = action.text(actionItem);
             button.addEventListener('click', () => {


### PR DESCRIPTION
This branch resolves issue #41

- You can now click on any unit to select it, even if it's not its turn or has no moves left.

#
- Added `getUnitsOnHex()` - finds all units on a hex
- Added new "Activate unit" action that shows in the menu when you click on a hex with units
- Updated `openUnitActionMenu()` to detect units and show activation options
- Shows unit type and how many moves it has left (e.g. "Activate settler (2 moves left)")
- Skips showing the currently active unit in the list (no point activating what's already active)
#
- Click on a hex with units -> menu shows all units there
